### PR TITLE
Implement testing for Web

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ license = "MIT OR Apache-2.0 OR Zlib"
 owo-colors = "3.5.0"
 winit = { version = "0.28.6", default-features = false }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-test = "0.3"
+web-time = "0.2"
+
 [dev-dependencies]
 winit = { version = "0.28.6", default-features = false, features = ["x11", "wayland"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@
 
 #![forbid(unsafe_code)]
 
+/// Re-exporting `wasm-bindgen-test`.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+pub use wasm_bindgen_test;
 /// Re-exporting `winit` for the sake of convenience.
 pub use winit;
 
@@ -11,7 +15,11 @@ pub use winit;
 #[macro_export]
 macro_rules! main {
     ($ty:ty => $($tt:tt)*) => {
+        #[cfg(target_arch = "wasm32")]
+        $crate::wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
         #[cfg(not(target_os = "android"))]
+        #[cfg_attr(target_arch = "wasm32", $crate::wasm_bindgen_test::wasm_bindgen_test)]
         fn main() -> Result<(), Box<dyn std::error::Error>> {
             const TESTS: &[$crate::__private::WinitBasedTest<$ty>] = &[
                 $crate::__winit_test_internal_collect_test!($($tt)*)
@@ -56,19 +64,33 @@ macro_rules! __winit_test_internal_collect_test {
 #[doc(hidden)]
 // This part is semver-exempt.
 pub mod __private {
-    use winit::event_loop::EventLoopBuilder;
     pub use winit::event_loop::EventLoopWindowTarget;
+    use winit::event_loop::{ControlFlow, EventLoopBuilder};
 
     use owo_colors::OwoColorize;
+    use std::any::Any;
     use std::panic::{catch_unwind, AssertUnwindSafe};
+    #[cfg(not(target_arch = "wasm32"))]
     use std::time::Instant;
+    #[cfg(target_arch = "wasm32")]
+    use web_time::Instant;
 
     #[cfg(target_os = "android")]
     pub use winit::platform::android::{
         activity::AndroidApp as Context, EventLoopBuilderExtAndroid,
     };
+    #[cfg(target_arch = "wasm32")]
+    use winit::platform::web::EventLoopExtWebSys;
     #[cfg(not(target_os = "android"))]
     pub type Context = ();
+
+    struct State {
+        passed: i32,
+        panics: Vec<(&'static str, Box<dyn Any + Send>)>,
+        start: Instant,
+        run: bool,
+        code: i32,
+    }
 
     /// Run a set of tests using a `winit` context.
     pub fn run<T: 'static>(tests: &'static [WinitBasedTest<T>], _ctx: Context) {
@@ -84,72 +106,87 @@ pub mod __private {
         let event_loop = builder.build();
 
         println!("\nRunning {} tests...", tests.len());
-        let mut passed = 0;
-        let mut panics = vec![];
-        let start = Instant::now();
-        let mut run = false;
-        let mut code = 0;
+        let mut state = State {
+            passed: 0,
+            panics: vec![],
+            start: Instant::now(),
+            run: false,
+            code: 0,
+        };
 
         // Run the tests.
+        #[cfg(not(target_arch = "wasm32"))]
         event_loop.run(move |_, elwt, control_flow| {
-            if run {
-                control_flow.set_exit_with_code(code);
-                return;
-            }
-            run = true;
-
-            for test in tests {
-                print!("test {} ... ", test.name);
-
-                match test.function {
-                    TestFunction::Oneoff(f) => {
-                        match catch_unwind(AssertUnwindSafe(move || f(elwt))) {
-                            Ok(()) => {
-                                println!("{}", "ok".green());
-                                passed += 1;
-                            }
-
-                            Err(e) => {
-                                println!("{}", "FAILED".red());
-                                panics.push((test.name, e));
-                            }
-                        }
-                    }
-                }
-            }
-
-            let failures = panics.len();
-            println!();
-            if !panics.is_empty() {
-                println!("failures:\n");
-                for (name, e) in panics.drain(..) {
-                    println!("---- {} panic ----", name);
-
-                    if let Some(s) = e.downcast_ref::<&'static str>() {
-                        println!("{}", s.red());
-                    } else if let Some(s) = e.downcast_ref::<String>() {
-                        println!("{}", s.red());
-                    } else {
-                        println!("{}", "unknown panic type".red());
-                    }
-
-                    println!();
-                }
-
-                print!("test result: {}", "FAILED".red());
-            } else {
-                print!("test result: {}", "ok".green());
-            }
-
-            let elapsed = start.elapsed();
-            println!(
-                ". {} passed; {} failed; finished in {:?}",
-                passed, failures, elapsed
-            );
-
-            code = if failures == 0 { 0 } else { 1 };
-            control_flow.set_exit_with_code(code);
+            run_internal(tests, &mut state, elwt, control_flow);
         });
+        #[cfg(target_arch = "wasm32")]
+        event_loop.spawn(move |_, elwt, control_flow| {
+            run_internal(tests, &mut state, elwt, control_flow);
+        });
+    }
+
+    /// Run a set of tests using a `winit` context.
+    fn run_internal<T: 'static>(
+        tests: &'static [WinitBasedTest<T>],
+        state: &mut State,
+        elwt: &EventLoopWindowTarget<T>,
+        control_flow: &mut ControlFlow,
+    ) {
+        if state.run {
+            control_flow.set_exit_with_code(state.code);
+            return;
+        }
+        state.run = true;
+
+        for test in tests {
+            print!("test {} ... ", test.name);
+
+            match test.function {
+                TestFunction::Oneoff(f) => match catch_unwind(AssertUnwindSafe(move || f(elwt))) {
+                    Ok(()) => {
+                        println!("{}", "ok".green());
+                        state.passed += 1;
+                    }
+
+                    Err(e) => {
+                        println!("{}", "FAILED".red());
+                        state.panics.push((test.name, e));
+                    }
+                },
+            }
+        }
+
+        let failures = state.panics.len();
+        println!();
+        if !state.panics.is_empty() {
+            println!("failures:\n");
+            for (name, e) in state.panics.drain(..) {
+                println!("---- {} panic ----", name);
+
+                if let Some(s) = e.downcast_ref::<&'static str>() {
+                    println!("{}", s.red());
+                } else if let Some(s) = e.downcast_ref::<String>() {
+                    println!("{}", s.red());
+                } else {
+                    println!("{}", "unknown panic type".red());
+                }
+
+                println!();
+            }
+
+            print!("test result: {}", "FAILED".red());
+        } else {
+            print!("test result: {}", "ok".green());
+        }
+
+        let elapsed = state.start.elapsed();
+        println!(
+            ". {} passed; {} failed; finished in {:?}",
+            state.passed, failures, elapsed
+        );
+
+        state.code = if failures == 0 { 0 } else { 1 };
+        control_flow.set_exit_with_code(state.code);
     }
 
     pub struct WinitBasedTest<T: 'static> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,6 @@
 
 #![forbid(unsafe_code)]
 
-/// Re-exporting `wasm-bindgen-test`.
-#[cfg(target_arch = "wasm32")]
-#[doc(hidden)]
-pub use wasm_bindgen_test;
 /// Re-exporting `winit` for the sake of convenience.
 pub use winit;
 
@@ -16,10 +12,10 @@ pub use winit;
 macro_rules! main {
     ($ty:ty => $($tt:tt)*) => {
         #[cfg(target_arch = "wasm32")]
-        $crate::wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+        $crate::__private::wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
         #[cfg(not(target_os = "android"))]
-        #[cfg_attr(target_arch = "wasm32", $crate::wasm_bindgen_test::wasm_bindgen_test)]
+        #[cfg_attr(target_arch = "wasm32", $crate::__private::wasm_bindgen_test::wasm_bindgen_test)]
         fn main() -> Result<(), Box<dyn std::error::Error>> {
             const TESTS: &[$crate::__private::WinitBasedTest<$ty>] = &[
                 $crate::__winit_test_internal_collect_test!($($tt)*)
@@ -64,6 +60,9 @@ macro_rules! __winit_test_internal_collect_test {
 #[doc(hidden)]
 // This part is semver-exempt.
 pub mod __private {
+    #[cfg(target_arch = "wasm32")]
+    pub use wasm_bindgen_test;
+
     pub use winit::event_loop::EventLoopWindowTarget;
     use winit::event_loop::{ControlFlow, EventLoopBuilder};
 


### PR DESCRIPTION
Apologies for the delay.

I moved the code going into [`EventLoop::run()`](https://docs.rs/winit/0.28.6/winit/event_loop/struct.EventLoop.html#method.run) into it's own function called `run_internal()`, to handle having to use [`EventLoop::spawn()`](https://docs.rs/winit/0.28.6/wasm32-unknown-unknown/winit/platform/web/trait.EventLoopExtWebSys.html#tymethod.spawn) for Wasm.